### PR TITLE
Initial of minerva docs from the Google Docs

### DIFF
--- a/software/minerva/index.rst
+++ b/software/minerva/index.rst
@@ -1,2 +1,18 @@
-Minerva
-=======
+Minerva Documentation
+=====================
+
+Welcome to the Waterloo Rocketry *Minerva* documentation hub.  Choose the guide that
+matches your role:
+
+* **User Guide** – how to interact with the bot in Slack (meeting reminders, /notify,
+  troubleshooting).
+* **Developer Guide** – onboarding, local setup, deployment pipeline, and operational
+  details for contributors.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Guides
+
+   minerva_user_guide
+   minerva_developer_guide
+

--- a/software/minerva/minerva_developer_guide.rst
+++ b/software/minerva/minerva_developer_guide.rst
@@ -1,0 +1,162 @@
+Minerva Developer Guide
+=======================
+
+.. note::
+
+   This guide is based on the original Minerva documentation in Google Docs:
+
+   - `Minerva Developer Reference <https://docs.google.com/document/d/1vz9b3J8ghjsyqJtUuTTT1KHH7F9GhhCrGC5Nmy-X3rQ>`__
+   - `Developer Onboarding <https://docs.google.com/document/d/1otYHtmFHzkN8g7089EGQpxi9-7C_iKFhDt2L2tuwxHs>`__
+
+This document is for **developers** who want to hack on the *minerva‑rewrite* Slackbot.  It combines the *Developer Onboarding* and *Developer Reference* PDFs.
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+1. Getting Access
+-----------------
+
+Development Slack Workspace
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* URL : ``https://waterloorocketrydev.slack.com``
+* Join via the *Development Slack Invite* pinned in **#software** or by DMing a contributor.
+* Messages older than **90 days** disappear due to free tier.
+
+Development Google Calendar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Calendar ID: ``uwaterloo.rocketry.dev@gmail.com``.
+* Request *“Make changes to events”* permission from the Software Lead.
+
+Oracle Cloud Instance
+^^^^^^^^^^^^^^^^^^^^^
+
+* Shape **VM.Standard.A1.Flex** - 4 vCPU, 24 GiB RAM .
+* Public IP: ``129.153.48.52``.
+* Runs two **PM2** apps: ``minerva`` (prod) and ``minerva-dev`` (dev).
+* To grant access, add the developer's SSH public key to ``~/.ssh/authorized_keys``.
+
+Slack Apps
+^^^^^^^^^^
+
+* **minerva** - production, **minerva-dev** - development.
+* Add collaborators via *Settings → Collaborators*; production access only for trusted devs.
+
+Optional Development Google Account
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Credentials for ``uwaterloo.rocketry.dev@gmail.com`` are available in **#accounts** (ask lead).
+
+
+2. Local Setup
+--------------
+
+Clone and bootstrap :
+
+::
+
+   git clone https://github.com/waterloo-rocketry/minerva-rewrite
+   cd minerva-rewrite
+   # Install Node ≥ 18 LTS and Yarn or pnpm
+   cp .env.example .env  # fill with dev secrets (see below)
+   yarn install
+   yarn start            # run locally
+
+
+3. Deployment Workflow
+----------------------
+
+Overview
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* GitHub Actions builds → SSHes into Oracle VM → swaps artefact.
+* Branch **development** → auto-deploys to dev workspace.
+* Branch **main** → auto-deploys to production after PR merge.
+
+Local Testing 
+^^^^^^^^^^^^^
+
+Run ``yarn start`` locally.  Avoid port clashes with the dev bot in Oracle Cloud; ensure your local ``.env`` uses dev tokens.
+
+Deploy to Development
+^^^^^^^^^^^^^^^^^^^^^
+
+Force-push to **development** *or* execute::
+
+   yarn deploy-dev
+
+Deploy to Production
+^^^^^^^^^^^^^^^^^^^^
+
+Merge PR → Actions run tests → deployment to prod Slack.
+
+Viewing Logs
+^^^^^^^^^^^^
+
+::
+
+   ssh ubuntu@129.153.48.52
+   pm2 list
+   pm2 logs minerva        # production
+   pm2 logs minerva-dev    # development
+
+
+4. Environment Variables
+------------------------
+
+Both dev and prod use these variables.
+
+.. list-table:: Environment Variables
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Variable
+     - Where to Get / Notes
+   * - ``GOOGLE_ACCOUNT_CLIENT``  
+       ``GOOGLE_ACCOUNT_SECRET``
+     - Google Cloud Console → *Credentials* of  
+       • Production: *waterloorocketry-minerva* project.  
+       • Dev: *rocketry-minerva* project.
+   * - ``GOOGLE_ACCOUNT_TOKEN``
+     - Generate new refresh token via Google OAuth  
+       Playground; scope ``calendar.events``.
+   * - ``GOOGLE_ACCOUNT_OAUTH_REDIRECT``
+     - Typically ``https://developers.google.com/oauthplayground/``.
+   * - ``SLACK_APP_TOKEN``  
+       ``SLACK_OAUTH_TOKEN``  
+       ``SLACK_SIGNING_SECRET``
+     - Slack API → *Basic Information → App-Level Tokens*  
+       Slack API → *OAuth & Permissions*   
+       Slack API → *Basic Information → App Credentials*
+   * - ``NODE_ENV``
+     - ``production`` or ``development`` to toggle runtime  
+       settings .
+   * - ``DEPLOY_COMMIT_SHA``
+     - Auto-injected by GitHub Actions at deploy.
+
+5. SSH Quick Commands
+---------------------
+
+::
+
+   # Restart dev bot safely
+   pm2 restart minerva-dev
+
+   # Tail last 200 lines
+   pm2 logs minerva --lines 200
+
+6. Onboarding Checklist
+-----------------------
+
+- Add dev to Development Slack.
+
+- Grant *Make changes to events* on Dev Calendar.
+
+- Add their SSH key to Oracle VM.
+
+- Provide ``.env`` dev secrets (DM or scp from server).
+
+- (Optional) Add as collaborator to **minerva-dev** Slack App.
+

--- a/software/minerva/minerva_user_guide.rst
+++ b/software/minerva/minerva_user_guide.rst
@@ -1,0 +1,136 @@
+Minerva Slackbot User Guide
+===========================
+
+.. note::
+
+   This guide is based on the original Minerva documentation in Google Docs:
+
+   - `Message Notify <https://docs.google.com/document/d/1otYHtmFHzkN8g7089EGQpxi9-7C_iKFhDt2L2tuwxHs>`__
+   - `Meetings (Calendar Events) <https://docs.google.com/document/d/1vz9b3J8ghjsyqJtUuTTT1KHH7F9GhhCrGC5Nmy-X3rQ>`__
+
+
+This guide explains how to use the Waterloo Rocketry **Minerva** Slackbot day-to-day.  It is intended for *all team members* (including single-channel guests) and covers meeting reminders, message notifications, and basic troubleshooting.
+
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+
+Meeting Reminders
+-----------------
+
+Minerva reads the **Waterloo Rocketry Google Calendar** and automatically posts two reminders for every event :
+
+* **Six hours** before the start time - includes ✅ / ❌ / ❓ reaction emojis to collect attendance.
+* **Five minutes** before - pings ``@channel`` in the meeting’s Slack channel.
+
+If a user is a *single-channel guest* of any *default channel* (see below) **and** cannot see the reminder in its channel, Minerva sends them a DM copy .
+
+Default Channels
+^^^^^^^^^^^^^^^^
+
+``#general``, ``#airframe``, ``#business``, ``#controls``, ``#electrical``,
+``#flight-dynamics``, ``#infrastructure``, ``#payload``, ``#propulsion``,
+``#recovery``, ``#software`` .
+
+Creating Events for Minerva
+---------------------------
+
+Minerva uses *plain-text* metadata stored in the **description** of a Google Calendar event .  Follow these steps:
+
+1. **Create** the event on the Waterloo Rocketry calendar.
+2. **Invite** Minerva to every Slack channel you want reminded (mention ``@minerva`` and click *Invite*).
+3. **Populate** the description:
+
+   *Line 1*   - meeting channel, e.g. ``#general``.  Append ``no-dm`` to suppress DMs to single-channel guests .
+
+   *Line 2*   - meeting URL, starting with ``http://`` or ``https://``.  If omitted, defaults to ``https://meet.waterloorocketry.com`` .
+
+   *Lines 3+* - free-form meeting description.
+
+4. (Optional) **Location** field - set a physical venue.
+
+Editing & Cancelling
+^^^^^^^^^^^^^^^^^^^^
+
+*Just edit the description*—Minerva re-parses automatically.  To cancel, add ``[CANCELLED]`` to the event title; reminders still send but the five-minute ping is suppressed .
+
+Manual Reminders
+^^^^^^^^^^^^^^^^
+
+Run in the meeting channel:
+
+::
+
+   /meeting-reminder [ping]
+
+This re-posts the next upcoming event; pass ``ping`` to force an ``@channel`` ping.
+
+Troubleshooting (Meetings)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **No reminder posted** → The event description metadata may be malformed; clear & rewrite.
+* **not_in_channel** error in **#minerva-log** → Invite @minerva to that channel.
+
+Message Notifications (/notify)
+-------------------------------
+
+Use **/notify** to reshare (or DM) a message link .
+
+Syntax
+^^^^^^
+
+::
+
+   /notify LINK {copy | copy-ping} [default] [#channel1 #channel2 …]
+
+Arguments
+~~~~~~~~~
+
+* **LINK** - Slack message URL (right-click → *Copy link*).
+* **copy | copy-ping** - optional notification type:
+
+  * *(omitted)* → DM single-channel guests in target channels.
+  * ``copy`` → repost the message in target channels.
+  * ``copy-ping`` → repost **and** ``@channel`` ping (use sparingly!).
+
+* **default / #channel…** - list of targets .
+
+  * ``default`` = all default channels listed above.  Combine with explicit channels as needed.
+
+Examples
+^^^^^^^^
+
+*DM single-channel guests in all default channels*
+
+::
+
+   /notify <link>
+
+*Copy to #electrical*
+
+::
+
+   /notify <link> copy #electrical
+
+*Mass ping (⚠️ disruptive!)*
+
+::
+
+   /notify <link> copy-ping default #weeb
+
+See additional examples in the appendix.
+
+Troubleshooting (/notify)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **not_in_channel** error → Invite @minerva to the target channel.
+
+Appendix A — Quick Reference
+----------------------------
+
+=======================  ============================================
+Command                  Purpose
+=======================  ============================================
+``/meeting-reminder``    Manually send next meeting reminder.
+``/notify``              Share a message with wider audience.
+=======================  ============================================


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the Waterloo Rocketry Minerva Slackbot, targeting both users and developers. It replaces the existing minimal documentation with structured guides for different roles, including onboarding, local setup, deployment, and bot usage. Below are the key changes grouped by theme:

### Documentation Structure and Overview:
* Updated `index.rst` to serve as a central hub for Minerva documentation, linking to the new User Guide and Developer Guide. The title was also updated to "Minerva Documentation" for clarity.

### Developer Guide:
* Added a detailed `minerva_developer_guide.rst` covering onboarding, local setup, deployment workflows, environment variables, SSH commands, and an onboarding checklist for new developers. This guide consolidates information from previous Google Docs into a single resource.

### User Guide:
* Added a `minerva_user_guide.rst` explaining how team members can use Minerva for meeting reminders, message notifications (`/notify`), and troubleshooting. Includes metadata requirements for calendar events and examples of bot commands.